### PR TITLE
import util.Locale to allow Locale.US notation.

### DIFF
--- a/src/boliu/TraClusterDoc.java
+++ b/src/boliu/TraClusterDoc.java
@@ -13,6 +13,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Scanner;
+import java.util.Locale;
 
 public class TraClusterDoc {
 	


### PR DESCRIPTION
It did not compile using jdk1.8.0_91
